### PR TITLE
mithril のバージョンを 2.0.0 に固定する

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "chat",
   "dependencies": {
-    "mithril": "~0.2.0"
+    "mithril": "0.2.0"
   }
 }


### PR DESCRIPTION
理由は分からないのですが、mithril 2.0.0 より新しいバージョンを使うと動作しません。そのため、バージョンを固定しました。
